### PR TITLE
Feature/improve cudnn handle management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ $(BIN_DIR)/%.o: $(SRC_DIR)/%.cu
 
 $(TARGET_EDGE): $(SRC_EDGE) $(OBJ_FILES)
 	mkdir -p $(BIN_DIR)
-	$(NVCC) $(CXXFLAGS) $(SRC_EDGE) $(OBJ_FILES) -o $(TARGET_EDGE) $(LDFLAGS)
+	$(CXX) $(CXXFLAGS) $(SRC_EDGE) $(OBJ_FILES) -o $(TARGET_EDGE) $(LDFLAGS)
 
 # Rules for running the applications
 run: $(TARGET_EDGE)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,19 @@ Elapsed time in nanoseconds:
 | gpu                   | 8443221916    | 33638334  |
 | w/o conv. to int      | 8401399737    | 33471712  |
 
-Explanation of this measurement will follow in upcoming PRs.
+Reduce gpu mem alloc / dealloc by removing this step from the frame processing. This yields an 
+improvement in runtime of roughly 5%
+
+Elapsed time in nanoseconds:
+|                       | Total         | per frame |
+|-|-|-|
+| incl. io              | 9823949656    | 39139241  |
+| excl. io              | 8311901920    | 33115147  |
+| gpu                   | 7938228023    | 31626406  |
+| w/o conv. to int      | 7930628447    | 31596129  |
+
+
+Explanation of this measurements will follow in upcoming PRs.
 
 From here, the README is outdated and needs to be rewritten.
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,19 @@ Elapsed time in nanoseconds:
 | gpu                   | 7938228023    | 31626406  |
 | w/o conv. to int      | 7930628447    | 31596129  |
 
+Now, creation and destruction of cudnn handles and tensor descriptors and the like is taken out of the frame processing. 
+Instead, these handles are now stored outside of the relevant methods. **This yields an additional improvement
+in runtime of roughly 81%** (wow!)
+
+Elapsed time in nanoseconds:
+|                       | Total         | per frame
+|-|-|-|
+| incl. io              | 5260741121    | 20959127
+| excl. io              | 2015754933    | 8030896
+| gpu                   | 1509760936    | 6014983
+| w/o conv. to int      | 1488816208    | 5931538
+
+So, only creating cudnn handles when needed really pays off. One might want to further investigate the difference of the cudnnHandle_t and other objects like cudnnTensorDescriptor_t and so forth.
 
 Explanation of this measurements will follow in upcoming PRs.
 

--- a/include/convolution.hpp
+++ b/include/convolution.hpp
@@ -3,8 +3,8 @@
 
 #include <cuda_runtime.h>
 #include <cudnn.h>
-#include <cassert>
 
+#include <cassert>
 #include <iostream>
 
 #define CHECK_CUDNN(status)                                                                      \

--- a/include/filter.hpp
+++ b/include/filter.hpp
@@ -36,24 +36,25 @@ class Filter {
           m_d_img_temp_1D{width, height},
           m_d_image_broadcast{width, height},
           m_d_img_edges(width, height),
-          m_conv_to_grayscale({{0.299f, 0.587f, 0.114f, 0.0f}}),
-          m_conv_broadcast_to_4_channels({{1.0f, 1.0f, 1.0f, 1.0f}}),
-          m_conv_horz({{-0.25, 0, 0.25,  //
-                        -0.5, 0, 0.5,    //
-                        -0.25, 0, 0.25}}),
-          m_conv_edges({{-0.25, 0, 0.25,      //
-                         -0.5, 0, 0.5,        //
-                         -0.25, 0, 0.25,      //
-                         -0.25, -0.5, -0.25,  //
-                         0, 0, 0,             //
-                         0.25, 0.5, 0.25}}),
-          m_conv_reduce_2D_to_1D({{1.0f, 1.0f}}),
-          m_conv_smooth({{
-              1.0f / 12.0f, 2.0f / 12.0f, 1.0f / 12.0f,  //
-              2.0f / 12.0f, 4.0f / 12.0f, 2.0f / 12.0f,  //
-              1.0f / 12.0f, 2.0f / 12.0f, 1.0f / 12.0f   //
-          }}),
-          m_conv_delete({{
+          m_conv_to_grayscale(m_gpu_session, {{0.299f, 0.587f, 0.114f, 0.0f}}),
+          m_conv_broadcast_to_4_channels(m_gpu_session, {{1.0f, 1.0f, 1.0f, 1.0f}}),
+          m_conv_horz(m_gpu_session, {{-0.25, 0, 0.25,  //
+                                       -0.5, 0, 0.5,    //
+                                       -0.25, 0, 0.25}}),
+          m_conv_edges(m_gpu_session, {{-0.25, 0, 0.25,      //
+                                        -0.5, 0, 0.5,        //
+                                        -0.25, 0, 0.25,      //
+                                        -0.25, -0.5, -0.25,  //
+                                        0, 0, 0,             //
+                                        0.25, 0.5, 0.25}}),
+          m_conv_reduce_2D_to_1D(m_gpu_session, {{1.0f, 1.0f}}),
+          m_conv_smooth(m_gpu_session, {{
+                                           1.0f / 12.0f, 2.0f / 12.0f, 1.0f / 12.0f,  //
+                                           2.0f / 12.0f, 4.0f / 12.0f, 2.0f / 12.0f,  //
+                                           1.0f / 12.0f, 2.0f / 12.0f, 1.0f / 12.0f   //
+                                       }}),
+          m_conv_delete(m_gpu_session,
+                        {{
                             -0.12f, -0.05f, -0.02f, -0.05f, -0.12f,  //
                             -0.05f, -0.01f, 0.0f,   -0.01,  -0.05f,  //
                             -0.02f, 0.0f,   1.0f,   0.0f,   -0.02f,  //
@@ -119,6 +120,7 @@ class Filter {
     mutable ImageGPU<float, 1> m_d_img_edges;
     mutable ImageGPU<float, 4> m_d_image_broadcast;
 
+    GpuSession m_gpu_session;
     Convolution<Kernel<float, 1, 1, 1, 4>, ImageGPU<float, 4>, ImageGPU<float, 1>>
         m_conv_to_grayscale;
     Convolution<Kernel<float, 4, 1, 1, 1>, ImageGPU<float, 1>, ImageGPU<float, 4>>

--- a/include/op_mult.hpp
+++ b/include/op_mult.hpp
@@ -45,42 +45,4 @@ class OpMult {
     float m_beta;
 };
 
-// // Initialize cuDNN
-// cudnnHandle_t cudnn;
-// cudnnCreate(&cudnn);
-
-// // Create descriptors for the input and output tensors
-// cudnnTensorDescriptor_t tensorDesc;
-// cudnnCreateTensorDescriptor(&tensorDesc);
-// cudnnSetTensor4dDescriptor(tensorDesc, CUDNN_TENSOR_NCHW, CUDNN_DATA_FLOAT, N, C, H, W);
-
-// // Create an OpTensor descriptor
-// cudnnOpTensorDescriptor_t opTensorDesc;
-// cudnnCreateOpTensorDescriptor(&opTensorDesc);
-// cudnnSetOpTensorDescriptor(opTensorDesc, CUDNN_OP_TENSOR_MUL, CUDNN_DATA_FLOAT,
-// CUDNN_PROPAGATE_NAN);
-
-// // Allocate memory for the tensor
-// float *d_input, *d_output;
-// cudaMalloc(&d_input, N * C * H * W * sizeof(float));
-// cudaMalloc(&d_output, N * C * H * W * sizeof(float));
-
-// // Set scaling factors
-// float alpha = 1.0f; // Scaling factor for input tensor
-// float beta = 0.0f;  // Scaling factor for the output tensor
-
-// // Perform the squaring operation
-// cudnnOpTensor(cudnn,
-//               opTensorDesc,
-//               &alpha, tensorDesc, d_input, // First input tensor
-//               &alpha, tensorDesc, d_input, // Second input tensor (same as the first for
-//               squaring) &beta, tensorDesc, d_output); // Output tensor
-
-// // Cleanup
-// cudnnDestroyOpTensorDescriptor(opTensorDesc);
-// cudnnDestroyTensorDescriptor(tensorDesc);
-// cudaFree(d_input);
-// cudaFree(d_output);
-// cudnnDestroy(cudnn);
-
 #endif  // OP_MULT_HPP


### PR DESCRIPTION
The goal of this PR is to reduce unneeded memory alocation / dealocation and cudnn creation / destruction steps. For the initial (naive) implementation, these steps were carried out repeatedly for each filter step. 

Performance measurements show a huge impact especially when reducing the amount of cudnn handle operations. For the performance measurements, an mp4 video clip was processed. The relevant  clip will be presented at a  later time on youtube.

(Times in ns)

naive implementation:
|                       | Total         | per frame |
|-|-|-|
| incl. io              | 10675647389   | 42532459  |
| excl. io              | 9140242967    | 36415310  |
| gpu                   | 8443221916    | 33638334  |
| w/o conv. to int      | 8401399737    | 33471712  |

Reduce gpu mem alloc / dealloc by removing this step from the frame processing. This yields an 
improvement in runtime of roughly 5%:
|                       | Total         | per frame |
|-|-|-|
| incl. io              | 9823949656    | 39139241  |
| excl. io              | 8311901920    | 33115147  |
| gpu                   | 7938228023    | 31626406  |
| w/o conv. to int      | 7930628447    | 31596129  |

Now, creation and destruction of cudnn handles and tensor descriptors and the like is taken out of the frame processing. 
Instead, these handles are now stored outside of the relevant methods. **This yields an additional improvement
in runtime of roughly 81%** (wow!):
|                       | Total         | per frame
|-|-|-|
| incl. io              | 5260741121    | 20959127
| excl. io              | 2015754933    | 8030896
| gpu                   | 1509760936    | 6014983
| w/o conv. to int      | 1488816208    | 5931538

So, only creating cudnn handles when needed really pays off. One might want to further investigate the difference of the cudnnHandle_t and other objects like cudnnTensorDescriptor_t and so forth.
